### PR TITLE
Minimize the blast radius of lock-counter bugs

### DIFF
--- a/istesting.go
+++ b/istesting.go
@@ -1,0 +1,9 @@
+//go:build go1.21
+
+package locker
+
+import "testing"
+
+func isTesting() bool {
+	return testing.Testing()
+}

--- a/istesting_go120.go
+++ b/istesting_go120.go
@@ -1,0 +1,7 @@
+//go:build !go1.21
+
+package locker
+
+func isTesting() bool {
+	return false
+}


### PR DESCRIPTION
Recycling objects with a sync.Pool risks amplifying the impact of bugs. If the object is not reset to be functionally indistinguishable from a newly-constructed one before being returned to the pool, the unlucky recipient of the recycled object could misbehave through no fault of its own. And what's worse, such bugs would likely manifest as Heisenbugs as they would only happen when objects returned to the pool are being reused, i.e. a program with lots of concurrency and lots of lock churn.

Make the pool optimization functionally transparent so the impact of counter bugs does not extend beyond the scope it would have had without the pool optimization. Defensively reset the lock counters before returning them to the pool and after taking them from the pool. And add testing-only code which asserts that the invariants are upheld to ensure that the defensive coding is not papering over real bugs.